### PR TITLE
Fix serial looping on disconnect

### DIFF
--- a/boardswarm/src/main.rs
+++ b/boardswarm/src/main.rs
@@ -47,7 +47,10 @@ trait Actuator: std::fmt::Debug + Send + Sync {
 }
 
 #[derive(Error, Debug)]
-pub enum ConsoleError {}
+pub enum ConsoleError {
+    #[error("Console was closed")]
+    Closed,
+}
 
 #[async_trait::async_trait]
 trait Console: std::fmt::Debug + Send + Sync {


### PR DESCRIPTION
Detect getting an EOF from a serial device (e.g. due to unplug) and bail out of the read loop at that point.